### PR TITLE
Updated str endpoint for other Azure Envs

### DIFF
--- a/deploy.ps1
+++ b/deploy.ps1
@@ -15,7 +15,6 @@ $webserverAdminCidr = $parameters.webserverAdminCidr
 $certPass = ConvertTo-SecureString $parameters.certPass -AsPlainText -Force
 $tenantId = (Get-AzContext).Tenant.Id
 $subId = (Get-AzContext).Subscription.Id
-$baseStorageUrl = "https://$($Name)stgacct.blob.core.windows.net/sub-builder"
 $logFile = "./deploy_$(get-date -format `"yyyyMMddhhmmsstt`").log"
 
 # Set preference variables
@@ -321,6 +320,7 @@ catch {
 Write-Host "INFO: Obtaining Storage Account context for artifact uploads..." -ForegroundColor green
 Write-Verbose -Message "Obtaining Storage Account context for artifact uploads..."
 $storageAccount = Get-AzStorageAccount -ResourceGroupName "$Name-rg" -Name "$($Name)stgacct"
+$baseStorageUrl = "$($storageAccount.PrimaryEndPoints.Blob)sub-builder"
 
 if (!$storageAccount) {
     Write-Host "ERROR: Unable to obtain storage context, exiting script!" -ForegroundColor red


### PR DESCRIPTION
Hey team, I have no way to test this since I don't have access to an EA but I updated this to hopefully work in Azure Gov, Azure China, etc.  You hardcoded str endpoints for Azure Commercial and all I did was use powershell to get the primaryendpoint blob of the storage account instead of hardcoding.  This should allow government customers to use it.  Let me know if you wish to discuss further.

ken